### PR TITLE
Add job to trigger workflow in infra repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,15 @@ jobs:
       - name: Log out of Docker Hub
         if: always()
         run: docker logout
+
+      - name: Trigger workflow in infra repository
+        uses: octokit/request-action@v2.x
+        with:
+         route: POST /repos/:owner/:repo/dispatches
+         owner: teodossidossev
+         repo: ci-infra
+         event_type: trigger-uat-event
+         client_payload: '{"ref":"main","description":"Triggered from ci-frontend"}'
+         mediaType: '{"previews": ["flash"]}'
+        env:
+         GITHUB_TOKEN: ${{ secrets.CI_INFRA_TOKEN }}


### PR DESCRIPTION
The update introduces a new job in the Github workflow file (.github/workflows/publish.yml). This job is designed to trigger a workflow in the infrastructure repository, specifically following the successful logout from Docker Hub. It makes use of 'octokit/request-action@v2.x' to initiate the new dispatch event.