### PR TITLE
Add Docker image auto-build and publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Build and Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: teodossidossev/mse2024-ui:${{ github.event.release.tag_name }}
+          context: .
+          file: ./Dockerfile
+
+      - name: Log out of Docker Hub
+        if: always()
+        run: docker logout
+


### PR DESCRIPTION
The commit introduces a new GitHub workflow for automating Docker image building and publishing whenever a new release is published. The workflow runs on the latest version of Ubuntu, performs a Docker login, builds and pushes the Docker image using provided credentials, and then logs out of Docker.